### PR TITLE
[blinux] Added support of UTF-8

### DIFF
--- a/blinux-bash/Dockerfile
+++ b/blinux-bash/Dockerfile
@@ -6,6 +6,10 @@ RUN zypper -n install \
     nano              \
     vim
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN useradd -md /home/bill bill
 USER bill
 WORKDIR /home/bill/workspace

--- a/blinux-make/Dockerfile
+++ b/blinux-make/Dockerfile
@@ -1,6 +1,10 @@
 FROM epitechcontent/blinux:latest
 MAINTAINER Thomas Dufour <thomas.dufour@epitech.eu>
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN useradd -md /home/bill bill
 USER bill
 

--- a/blinux/Dockerfile
+++ b/blinux/Dockerfile
@@ -24,6 +24,8 @@ RUN zypper -n install \
     tmux              \
     valgrind          \
     zip unzip
+RUN zypper -n install \
+    glibc-locale
 
 ADD minilibx /usr/src/minilibx
 RUN make -C /usr/src/minilibx install


### PR DESCRIPTION
Ajout du support de l'utf-8 dans l'image docker utilisée par la plateforme d'intégration

Maintenant:
[bill@676bf243aac6 workspace]$ locale
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=en_US.UTF-8
