### PR TITLE
Adding pip and pexpect to python3

### DIFF
--- a/blinux/Dockerfile
+++ b/blinux/Dockerfile
@@ -23,8 +23,10 @@ RUN zypper -n install          \
     php5-mbstring              \
     python-numpy               \
     python3                    \
+    python3-pip                \
     python3-numpy              \
     ruby
+RUN pip3 install -Iv pexpect==4.0.1
 RUN zypper -n install \
     tmux              \
     valgrind          \


### PR DESCRIPTION
pexpect 4.0.1 is needed for the correction of one or more _PSU_ projects 
